### PR TITLE
Minimal changes needed for libloadorder to support fallout 4

### DIFF
--- a/src/api/constants.cpp
+++ b/src/api/constants.cpp
@@ -49,3 +49,4 @@ const unsigned int LIBLO_GAME_TES4 = 2;
 const unsigned int LIBLO_GAME_TES5 = 3;
 const unsigned int LIBLO_GAME_FO3 = 4;
 const unsigned int LIBLO_GAME_FNV = 5;
+const unsigned int LIBLO_GAME_FO4 = 6;

--- a/src/api/constants.h
+++ b/src/api/constants.h
@@ -150,6 +150,7 @@ extern "C"
     LIBLO extern const unsigned int LIBLO_GAME_TES5;  /**< Game code for The Elder Scrolls V: Skyrim. */
     LIBLO extern const unsigned int LIBLO_GAME_FO3;  /**< Game code for Fallout 3. */
     LIBLO extern const unsigned int LIBLO_GAME_FNV;  /**< Game code for Fallout: New Vegas. */
+    LIBLO extern const unsigned int LIBLO_GAME_FO4;  /**< Game code for Fallout 4 */
 
     /**@}*/
 

--- a/src/api/libloadorder.cpp
+++ b/src/api/libloadorder.cpp
@@ -92,7 +92,7 @@ LIBLO unsigned int lo_create_handle(lo_game_handle * const gh,
                                     const char * const localPath) {
     if (gh == nullptr || gamePath == nullptr) //Check for valid args.
         return c_error(LIBLO_ERROR_INVALID_ARGS, "Null pointer passed.");
-    else if (gameId != LIBLO_GAME_TES3 && gameId != LIBLO_GAME_TES4 && gameId != LIBLO_GAME_TES5 && gameId != LIBLO_GAME_FO3 && gameId != LIBLO_GAME_FNV)
+    else if (gameId != LIBLO_GAME_TES3 && gameId != LIBLO_GAME_TES4 && gameId != LIBLO_GAME_TES5 && gameId != LIBLO_GAME_FO3 && gameId != LIBLO_GAME_FNV && gameId != LIBLO_GAME_FO4)
         return c_error(LIBLO_ERROR_INVALID_ARGS, "Invalid game specified.");
 
     //Set the locale to get encoding conversions working correctly.

--- a/src/api/libloadorder.cpp
+++ b/src/api/libloadorder.cpp
@@ -39,7 +39,7 @@ using namespace liblo;
 
 const unsigned int LIBLO_VERSION_MAJOR = 7;
 const unsigned int LIBLO_VERSION_MINOR = 6;
-const unsigned int LIBLO_VERSION_PATCH = 0;
+const unsigned int LIBLO_VERSION_PATCH = 1;
 
 /* Returns whether this version of libloadorder is compatible with the given
    version of libloadorder. */
@@ -188,8 +188,8 @@ LIBLO void lo_destroy_handle(lo_game_handle gh) {
 LIBLO unsigned int lo_set_game_master(lo_game_handle gh, const char * const masterFile) {
     if (gh == nullptr || masterFile == nullptr) //Check for valid args.
         return c_error(LIBLO_ERROR_INVALID_ARGS, "Null pointer passed.");
-    if (gh->Id() == LIBLO_GAME_TES5)
-        return c_error(LIBLO_ERROR_INVALID_ARGS, "Cannot change Skyrim's main master file.");
+    if (gh->LoadOrderMethod() == LIBLO_METHOD_TEXTFILE)
+        return c_error(LIBLO_ERROR_INVALID_ARGS, "Cannot change main master file from " + gh->MasterFile());
 
     try {
         gh->SetMasterFile(masterFile);
@@ -264,14 +264,16 @@ LIBLO unsigned int lo_fix_plugin_lists(lo_game_handle gh) {
             gh->activePlugins.Load(*gh);
         }
 
-        if (gh->Id() == LIBLO_GAME_TES5) {
-            // Ensure Skyrim.esm is active.
+        if (gh->LoadOrderMethod() == LIBLO_METHOD_TEXTFILE) {
+            // Ensure main master file is active.
             if (gh->activePlugins.find(Plugin(gh->MasterFile())) == gh->activePlugins.end())
                 gh->activePlugins.insert(Plugin(gh->MasterFile()));
 
-            // Ensure Update.esm is active, if it is installed.
-            if (Plugin("Update.esm").Exists(*gh) && gh->activePlugins.find(Plugin("Update.esm")) == gh->activePlugins.end())
-                gh->activePlugins.insert(Plugin("Update.esm"));
+            if (gh->Id() == LIBLO_GAME_TES5) {
+                // Ensure Update.esm is active, if it is installed.
+                if (Plugin("Update.esm").Exists(*gh) && gh->activePlugins.find(Plugin("Update.esm")) == gh->activePlugins.end())
+                    gh->activePlugins.insert(Plugin("Update.esm"));
+            }
         }
 
         //Now check all plugins' existences.

--- a/src/backend/game.cpp
+++ b/src/backend/game.cpp
@@ -141,8 +141,8 @@ void _lo_game_handle_int::InitPaths(const boost::filesystem::path& localPath) {
 }
 
 void _lo_game_handle_int::SetMasterFile(const string& file) {
-    if (id == LIBLO_GAME_TES5)
-        throw error(LIBLO_ERROR_INVALID_ARGS, "Cannot change Skyrim's main master file.");
+    if (loMethod == LIBLO_METHOD_TEXTFILE)
+        throw error(LIBLO_ERROR_INVALID_ARGS, "Cannot change game's main master file.");
     else if (!Plugin(file).Exists(*this))
         throw error(LIBLO_ERROR_FILE_NOT_FOUND, "\"" + file + "\" cannot be found.");
     else if (!Plugin(file).IsValid(*this))

--- a/src/backend/game.cpp
+++ b/src/backend/game.cpp
@@ -83,6 +83,14 @@ _lo_game_handle_int::_lo_game_handle_int(unsigned int gameId, const string& path
         appdataFolderName = "FalloutNV";
         espm_settings = espm::Settings("fonv");
     }
+    else if (id == LIBLO_GAME_FO4) {
+        loMethod = LIBLO_METHOD_TEXTFILE;
+        masterFile = "Fallout4.esm";
+        appdataFolderName = "Fallout4";
+        // For now just use TES5 settings, until libesmp
+        // is updated as well.
+        espm_settings = espm::Settings("tes5");
+    }
 
 #ifdef _WIN32
     InitPaths(GetLocalAppDataPath() / appdataFolderName);


### PR DESCRIPTION
Just the minimum changes I deemed necessary to get Fallout 4 working with libloadorder.  There is one hacky spot, which is I just used the TES5 setting when accessing libespm.
